### PR TITLE
GROUP-101 Updated Event Consumer to Drop Errors

### DIFF
--- a/config/pmd/design.xml
+++ b/config/pmd/design.xml
@@ -45,7 +45,7 @@
     <rule ref="category/java/design.xml/TooManyFields" />
     <rule ref="category/java/design.xml/TooManyMethods">
         <properties>
-            <property name="maxmethods" value="20" />
+            <property name="maxmethods" value="25" />
         </properties>
     </rule>
     <rule ref="category/java/design.xml/UselessOverridingMethod" />

--- a/src/main/java/org/grouphq/groupsync/groupservice/domain/outbox/OutboxEvent.java
+++ b/src/main/java/org/grouphq/groupsync/groupservice/domain/outbox/OutboxEvent.java
@@ -49,6 +49,10 @@ public class OutboxEvent {
     }
 
     public static OutboxEvent convertEventDataToPublic(OutboxEvent outboxEvent) {
+        if (outboxEvent.getEventStatus() == EventStatus.FAILED) {
+            return outboxEvent;
+        }
+
         return switch (outboxEvent.getEventType()) {
             case MEMBER_JOINED, MEMBER_LEFT -> convertMember(outboxEvent);
             default -> outboxEvent;

--- a/src/test/java/org/grouphq/groupsync/group/domain/OutboxEventTest.java
+++ b/src/test/java/org/grouphq/groupsync/group/domain/OutboxEventTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.grouphq.groupsync.GroupTestUtility;
 import org.grouphq.groupsync.groupservice.domain.members.Member;
+import org.grouphq.groupsync.groupservice.domain.outbox.ErrorData;
 import org.grouphq.groupsync.groupservice.domain.outbox.OutboxEvent;
+import org.grouphq.groupsync.groupservice.domain.outbox.enums.EventStatus;
 import org.grouphq.groupsync.groupservice.domain.outbox.enums.EventType;
 import org.grouphq.groupsync.groupservice.web.objects.egress.PublicMember;
 import org.junit.jupiter.api.DisplayName;
@@ -34,5 +36,17 @@ class OutboxEventTest {
         final OutboxEvent convertedOutboxEvent = OutboxEvent.convertEventDataToPublic(outboxEvent);
 
         assertThat(convertedOutboxEvent.getEventData()).isExactlyInstanceOf(PublicMember.class);
+    }
+
+    @Test
+    @DisplayName("Does not perform any conversion for failed events")
+    void doesNotPerformAnyConversionForFailedEvents() {
+        final ErrorData errorData = new ErrorData("Error message");
+        final OutboxEvent outboxEvent = GroupTestUtility.generateOutboxEvent(
+            1L, errorData, EventType.MEMBER_JOINED, EventStatus.FAILED);
+
+        final OutboxEvent nonConvertedEvent = OutboxEvent.convertEventDataToPublic(outboxEvent);
+
+        assertThat(nonConvertedEvent).isEqualTo(outboxEvent);
     }
 }

--- a/src/test/java/org/grouphq/groupsync/group/event/GroupEventForwarderIntegrationTest.java
+++ b/src/test/java/org/grouphq/groupsync/group/event/GroupEventForwarderIntegrationTest.java
@@ -116,9 +116,12 @@ class GroupEventForwarderIntegrationTest {
     @DisplayName("Forwards events to the outbox event update failed sink")
     void forwardsEventsToTheOutboxEventUpdateFailedSink() {
         final List<OutboxEvent> outboxEvents = List.of(
-            GroupTestUtility.generateOutboxEvent(USER, EventStatus.FAILED),
-            GroupTestUtility.generateOutboxEvent(USER, EventStatus.FAILED),
-            GroupTestUtility.generateOutboxEvent(USER, EventStatus.FAILED)
+            GroupTestUtility.generateOutboxEvent(USER, EventStatus.FAILED, EventType.GROUP_CREATED),
+            GroupTestUtility.generateOutboxEvent(USER, EventStatus.FAILED, EventType.GROUP_UPDATED),
+            GroupTestUtility.generateOutboxEvent(USER, EventStatus.FAILED, EventType.GROUP_DISBANDED),
+            GroupTestUtility.generateOutboxEvent(USER, EventStatus.FAILED, EventType.MEMBER_JOINED),
+            GroupTestUtility.generateOutboxEvent(USER, EventStatus.FAILED, EventType.MEMBER_LEFT),
+            GroupTestUtility.generateOutboxEvent(USER, EventStatus.FAILED, EventType.NOTHING)
         );
 
         final Flux<OutboxEvent> groupUpdatesStream =

--- a/src/test/java/org/grouphq/groupsync/group/event/GroupEventForwarderTest.java
+++ b/src/test/java/org/grouphq/groupsync/group/event/GroupEventForwarderTest.java
@@ -1,6 +1,6 @@
 package org.grouphq.groupsync.group.event;
 
-import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import org.grouphq.groupsync.GroupTestUtility;
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Tag("UnitTest")
 @ExtendWith(MockitoExtension.class)
@@ -35,8 +36,8 @@ class GroupEventForwarderTest {
         final PublicOutboxEvent publicOutboxEvent =
             PublicOutboxEvent.convertOutboxEvent(outboxEvent);
 
-        willDoNothing().given(groupUpdateService).sendPublicOutboxEventToAll(publicOutboxEvent);
-        willDoNothing().given(groupUpdateService).sendOutboxEventToEventOwner(outboxEvent);
+        given(groupUpdateService.sendPublicOutboxEventToAll(publicOutboxEvent)).willReturn(Mono.empty());
+        given(groupUpdateService.sendOutboxEventToEventOwner(outboxEvent)).willReturn(Mono.empty());
 
         groupEventForwarder.processedEvents().accept(Flux.just(outboxEvent));
 
@@ -50,7 +51,7 @@ class GroupEventForwarderTest {
         final OutboxEvent outboxEvent =
             GroupTestUtility.generateOutboxEvent("ID", EventStatus.FAILED);
 
-        willDoNothing().given(groupUpdateService).sendOutboxEventToEventOwner(outboxEvent);
+        given(groupUpdateService.sendOutboxEventToEventOwner(outboxEvent)).willReturn(Mono.empty());
 
         groupEventForwarder.processedEvents().accept(Flux.just(outboxEvent));
 


### PR DESCRIPTION
<!--- Make sure to add GROUP-# (with # your related issue number) at the beginning of your pull request title, followed by a space! -->
### Description of Changes
The reactive stream for the processed events consumer in group sync has been misconfigured. If an error occurs in the stream, the `onErrorResume` operator drops the entire stream by switching to an empty mono, instead of just logging and dropping the error. Only realizing it now after a recent update to the reactive chain led to an error occurring in production.

The error occurs when trying to convert event data to its public type for a failed event--which is always of type ErrorModel and does not have a public version. Yet the current implementation will try to convert it to its public type as if it was successful based on the event’s event type (e.g. if the event type is MEMBER_JOINED, it will try to convert the event data to a `PublicMember` type, since it expects a `MemberModel` type for the event data, which is true only if the event is successful). 

This pull request includes the following changes:
- Nest the `onErrorResume` operator in the `forwardUpdate` call so that if an error is ever thrown from that call, it will just return an empty mono for that call instead of switching the entire stream to an empty stream.
- Updates the `forwardUpdate` method and any downstream methods to return deferred monos instead of just nothing. This actually should have been the initial implementation. Without wrapping the logic in a deferred mono, Reactor will end up calling all downstream methods prematurely when assembling the reactive chain (something I didn't know back when I wrote this a few months back)
- Update the event data model conversion methods to return if the event is not successful, preventing erroneous conversions

Tests have been added and updated to verify the new behavior and prevent future regressions
