### PR TITLE
GROUP-103 Auto-delete Consumer Queues After Shutdown

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,11 @@ spring:
       definition: |
         processedEvents;
     stream:
+      rabbit:
+        bindings:
+          processedEvents-in-0:
+            consumer:
+              anonymous-group-prefix: ${spring.application.name}
       bindings:
         groupCreateRequests-out-0:
           destination: group-create-requests
@@ -62,7 +67,6 @@ spring:
           group: ${spring.application.name}
         processedEvents-in-0:
           destination: group-event-results
-          group: ${spring.application.name}-${random.value}
   rabbitmq:
     host: {$SPRING_RABBITMQ_HOST:localhost}
     port: 5672


### PR DESCRIPTION
<!--- Make sure to add GROUP-# (with # your related issue number) at the beginning of your pull request title, followed by a space! -->
### Description of Changes
In a recent update, Group Sync instances were assigned a unique consumer queue to the group event exchange on RabbitMQ. This was configured through Spring Cloud Stream. The issue with this is those queues aren't deleted after the application is shutdown. Since those queues are unique to the instance that create them, they then accumulate messages until the memory limit has been exceeded.

The following configuration change has been added:

```yml
spring:
  cloud:
    stream:
      rabbit:
        bindings:
          processedEvents-in-0:
            consumer:
              anonymous-group-prefix: ${spring.application.name}
```

This change adds configuration specific to using the RabbitMQ binder to create an anonymous queue, which according to the [Spring RabbitMQ docs:](https://docs.spring.io/spring-cloud-stream-binder-rabbit/docs/current/reference/html/spring-cloud-stream-binder-rabbit.html#_rabbitmq_consumer_properties)

> anonymousGroupPrefix
When the binding has no `group` property, an anonymous, auto-delete queue is bound to the destination exchange. The default naming stragegy for such queues results in a queue named `anonymous.<base64 representation of a UUID>`. Set this property to change the prefix to something other than the default.
Default: `anonymous.`.

This also meant having to remove the `group` property for the consumer queue in the Spring Cloud Stream configuration:
```yml
spring:
  cloud:
    stream:
      bindings:
          destination: group-event-results
          group: ${spring.application.name}-${random.value} # This line removed
```

Once this change goes into place, the pods will be restarted. Their old queues will be deleted manually via the RabbitMQ Admin dashboard in production, which isn't too bad since there are only two.